### PR TITLE
Adjust Windows builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,14 +18,6 @@ environment:
       CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x86
-      CONDA_PY: 35
-      CONDA_INSTALL_LOCN: C:\\Miniconda35
-
-    - TARGET_ARCH: x64
-      CONDA_PY: 35
-      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
-
-    - TARGET_ARCH: x86
       CONDA_PY: 36
       CONDA_INSTALL_LOCN: C:\\Miniconda36
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,8 @@ build:
 
 {% if OSX_VARIANT != "native" %}
   skip: True  # [not osx]
+{% else %}
+  skip: True  # [win and py35]
 {% endif %}
 
   features:


### PR DESCRIPTION
Disables Python 3.5 Windows builds as they use the same VC as Python 3.6. Since we aren't building Python packages here, it makes sense to use just one.